### PR TITLE
indented-xml-string: simplify handling of Apple-restricted chars

### DIFF
--- a/splitflap-lib/private/dust.rkt
+++ b/splitflap-lib/private/dust.rkt
@@ -3,6 +3,8 @@
 (require (for-syntax racket/base)
          racket/port
          racket/string
+         racket/match
+         racket/list
          txexpr
          xml)
 
@@ -39,74 +41,105 @@
 
 ;; ~~ HTML entity escaping ~~~~~~~~~~~~~~~~~~~~~~~
 
-;; The xml display functions take care of escaping #\& #\< and #\> inside content strings.
-;; However we need to be able to escape other characters in some circumstances (for podcast
-;; feeds in particular) and those escapes themselves include the ampersand character.
-;; The solution is to pre-escape the extra characters immediately before converting to xml,
-;; and then unescape the ampersands after converting the xml to a string.
+;; Apple requires that the following characters not be used in PCDATA, even though they
+;; are permitted by the XML spec:
+;;
+;;   #\' #\\ #\" #\© #\℗ #\™
+;;
+;; Instead, the must be referred to via predefined entity or character references.
+;; See: https://podcasters.apple.com/support/823-podcast-requirements
+;; (Apple does not give a reason for this requirement, and it groups them together
+;; with #\&, #\<, and #\>, which are disallowed by the standard and thus replaced
+;; automatically by the XML library.)
+;;
+;; So, we must find those symbols in text strings and extract the appropriate references.
 
-;; This is the set of characters (besides #\& #\< and #\>) that Apple gets snippy about.
-;; See https://podcasters.apple.com/support/823-podcast-requirements
-
-(define (pre-escape-entities str)
-  (define char-escapes
-    (hash 
-     "'" "%amp%apos;"
-     "\"" "%amp%quot;"
-     "©" "%amp%#xA9;"
-     "℗" "%amp%#x2117;"
-     "™" "%amp%#x2112;"))
-  (regexp-replace*
-   #rx"['\"©℗™]"
-   str
-   (lambda (match-str)
-     (hash-ref char-escapes match-str match-str))))
-
-(define (post-escape-entities str)
-  (string-replace str "%amp%" "&"))
+;; escape-for-apple: (-> string? (listof (or/c string? symbol? valid-char?)))
+(define (escape-for-apple str)
+  (match (regexp-match-positions* #rx"['\"©℗™]" str)
+    ;; Don't copy the string unless necessary:
+    ['()
+     (list str)]
+    [to-escape
+     (let loop ([gap-end (string-length str)]
+                [to-escape (reverse to-escape)]
+                [acc null])
+       (match to-escape
+         ['()
+          (if (zero? gap-end)
+              acc
+              (cons (substring str 0 gap-end)
+                    acc))]
+         [(cons (cons pos gap-start) to-escape)
+          (loop pos
+                to-escape
+                (cons (match (string-ref str pos)
+                        [#\' 'apos]
+                        [#\" 'quot]
+                        [#\© #xA9]
+                        [#\℗ #x2117]
+                        [#\™ #x2122])
+                      (if (= gap-start gap-end)
+                          acc
+                          (cons (substring str gap-start gap-end)
+                                acc))))]))]))
 
 (module+ test
+  ;; Cases to cover:
+  ;;   - first/last character needing/not nedding to be escaped
+  ;;   - two adjacent characters needing to be escaped
+  ;;   - avoid pointless copies
   (define test-str1 "Punch & Judy's friend \"George\"")
-  (define test-str2 "<h1>© ℗ Product™")
-  (check-equal? (pre-escape-entities test-str1)
-                "Punch & Judy%amp%apos;s friend %amp%quot;George%amp%quot;")
-  (check-equal? (pre-escape-entities test-str2)
-                "<h1>%amp%#xA9; %amp%#x2117; Product%amp%#x2112;")
-
-  (check-equal? (post-escape-entities (pre-escape-entities test-str1))
-                "Punch & Judy&apos;s friend &quot;George&quot;")
-  (check-equal? (post-escape-entities (pre-escape-entities test-str2))
-                "<h1>&#xA9; &#x2117; Product&#x2112;")
+  (define test-str2 "™<h1>©℗ Product")
+  (check-equal? (escape-for-apple test-str1)
+                '("Punch & Judy" apos "s friend " quot "George" quot))
+  (check-equal? (escape-for-apple test-str2)
+                '(#x2122 "<h1>" #xA9 #x2117 " Product"))
+  (let ([already-sanitary-string "abcdefg"])
+    (check-eq? (car (escape-for-apple already-sanitary-string))
+               already-sanitary-string))
+  ;; Check that we've typed the non-ASCII characters properly:
+  (for ([int (in-list '(#xA9 #x2117 #x2122))])
+    (define char (integer->char int))
+    (with-check-info (('valid-char? int)
+                      ('char? char))
+      (check-equal? (escape-for-apple (string char))
+                    (list int)
+                    "character references should round-trip")))
   )
 
 ;; Recursively pre-escape any string entities in an x-expression that
 ;; are direct children of an element whose ‘type’ attribute is “text”
-(define (pre-escape x)
+(define (txexpr->apple-txexpr x)
   (cond 
     [(and (txexpr? x) (equal? "text" (attr-ref x 'type #f)))
      (txexpr
       (car x)
       (get-attrs x)
-      (map (λ (c) (if (string? c) (pre-escape-entities c) (pre-escape c))) (get-elements x)))]
-    [(txexpr? x) (txexpr (car x) (get-attrs x) (map pre-escape (get-elements x)))]
+      (append-map (λ (c)
+                    (if (string? c)
+                        (escape-for-apple c)
+                        (list (txexpr->apple-txexpr c))))
+                  (get-elements x)))]
+    [(txexpr? x) (txexpr (car x) (get-attrs x) (map txexpr->apple-txexpr (get-elements x)))]
     [else x]))
 
 (module+ test
   (define judy-str "Judy's friend \"George\"")
   ;; no effect without '(type "text") in attrs
-  (check-equal? (pre-escape `(div (div [[id "t's"]] ,judy-str (div ,judy-str))))
+  (check-equal? (txexpr->apple-txexpr `(div (div [[id "t's"]] ,judy-str (div ,judy-str))))
                 `(div (div [[id "t's"]] ,judy-str (div ,judy-str))))
 
   ;; escapes with '(type "text") in attrs, but only immediate child strings
-  (check-equal? (pre-escape `(div (div [[type "text"]] ,judy-str (div ,judy-str))))
-                `(div (div [[type "text"]] "Judy%amp%apos;s friend %amp%quot;George%amp%quot;" (div ,judy-str)))))
+  (check-equal? (txexpr->apple-txexpr `(div (div [[type "text"]] ,judy-str (div ,judy-str))))
+                `(div (div [[type "text"]] "Judy" apos "s friend " quot "George" quot (div ,judy-str)))))
 
 ;; ~~ XML Display ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ;; Convert an xexpr to a string with escaped and nicely-indented XML.
 (define (indented-xml-string xpr #:document? [doc? #f])
   (define x
-    (let ([pxpr (pre-escape xpr)])
+    (let ([pxpr (txexpr->apple-txexpr xpr)])
       (if doc? (xml-document pxpr) (xexpr->xml pxpr))))
   (define display-proc (if doc? display-xml display-xml/content))
   (define xml-str
@@ -114,7 +147,7 @@
       (λ ()
         (parameterize ([empty-tag-shorthand 'always])
           (display-proc x #:indentation 'peek)))))
-  (string-trim (post-escape-entities xml-str) #:right? #f))
+  (string-trim xml-str #:right? #f))
 
 (module+ test
   (define test-xpr


### PR DESCRIPTION
Instead of an ad-hoc scheme of pre-escaping and un-escaping,
convert string x-expressions containing these characters into
(lists of) equivalent x-expressions using the Racket representations
of the entity and character references Apple mandates,
and let the XML library take care of the rest.