### PR TITLE
Incorporate feedback from Racket users

### DIFF
--- a/splitflap-doc/constructs.scrbl
+++ b/splitflap-doc/constructs.scrbl
@@ -61,8 +61,8 @@ things that your feed is serving. See @racket[tag-specific-string?] for informat
 characters are allowed here.
 
 @examples[#:eval mod-constructs
-          (mint-tag-uri "rclib.org" "2012-04-01" "Marian'sBlog")
-          (mint-tag-uri "diveintomark.org" "2003" "3.2397")]
+          (mint-tag-uri "rclib.example.com" "2012-04-01" "Marian'sBlog")
+          (mint-tag-uri "diveintomark.example.com" "2003" "3.2397")]
 
 }
 
@@ -71,7 +71,7 @@ characters are allowed here.
 Converts a @racketlink[mint-tag-uri]{@tt{tag-uri}} into a string.
 
 @examples[#:eval mod-constructs
-          (define rclib-id (mint-tag-uri "rclib.org" "2012-04-01" "Marian'sBlog"))
+          (define rclib-id (mint-tag-uri "rclib.example.com" "2012-04-01" "Marian'sBlog"))
           (tag-uri->string rclib-id)]
 
 }
@@ -83,7 +83,7 @@ the tag URI.  This allows you to append to a feed’s @tech{tag URI} to create u
 the items within that feed.
 
 @examples[#:eval mod-constructs
-          (define kottke-id (mint-tag-uri "kottke.org" "2005-12" "1"))
+          (define kottke-id (mint-tag-uri "kottke.example.com" "2005-12" "1"))
           kottke-id
           (append-specific kottke-id "post-slug")]
 
@@ -146,7 +146,7 @@ considers people to be synonymous with email addresses. So @racket[person] requi
 Converts @racket[_p] into a tagged X-expresssion using @racket[_entity] as enclosing tag name.
 
 @examples[#:eval mod-constructs
-          (define frank (person "Frank Abignale" "fabignale@panam.com"))
+          (define frank (person "Frankincense Pontipee" "frank@example.com"))
           (person->xexpr frank 'author 'atom)
           (person->xexpr frank 'contributor 'atom)
           (person->xexpr frank 'author 'rss)
@@ -238,7 +238,7 @@ This procedure accesses the filesystem; if @racket[_file] does not exist, an exc
           (write-to-file (make-bytes 100 65) audio-file #:exists 'replace)
           (code:comment @#,elem{Pass the temp file to an enclosure})
           (display
-           (express-xml (file->enclosure audio-file "http://rclib.org/episodes") 'atom))
+           (express-xml (file->enclosure audio-file "http://rclib.example.com/episodes") 'atom))
           (code:comment @#,elem{Cleanup})
           (delete-file audio-file)]
 }
@@ -292,15 +292,15 @@ valid URL is one which, when parsed with @racket[string->url], includes a valid 
 address).
 
 @examples[#:eval mod-constructs
-          (valid-url-string? "http://rclib.org")
-          (valid-url-string? "telnet://rclib.org")
-          (code:line (valid-url-string? "gonzo://rclib.org") (code:comment @#,elem{scheme need not be registered}))
-          (code:line (valid-url-string? "https://user:p@joeldueck.com:8080") (code:comment @#,elem{includes user/password/port}))
+          (valid-url-string? "http://rclib.example.com")
+          (valid-url-string? "telnet://rclib.example.com")
+          (code:line (valid-url-string? "gonzo://example.com") (code:comment @#,elem{scheme need not be registered}))
+          (code:line (valid-url-string? "https://user:p@example.com:8080") (code:comment @#,elem{includes user/password/port}))
           (code:line (valid-url-string? "file://C:\\home\\user?q=me") (code:comment @#,elem{Look, you do you}))
           code:blank
           (code:comment @#,elem{Valid URIs but not URLs:})
           (code:line (valid-url-string? "news:comp.servers.unix") (code:comment @#,elem{no host given, only path}))
-          (code:line (valid-url-string? "http://subdomain-.ape.net") (code:comment @#,elem{invalid label}))
+          (code:line (valid-url-string? "http://subdomain-.example.com") (code:comment @#,elem{invalid label}))
           code:blank
           (code:line (code:comment @#,elem{Valid URLs but not allowed by this library for use in feeds}))
           (code:line (valid-url-string? "ldap://[2001:db8::7]/c=GB?objectClass?one") (code:comment @#,elem{Host is not a DNS domain}))
@@ -327,12 +327,12 @@ common-sense subset of RFC 5322:
 ]
 
 @examples[#:eval mod-constructs
-          (email-address? "test-email.with+symbol@domain.com")
-          (email-address? "#!$%&'*+-/=?^_{}|~@domain.org")
+          (email-address? "test-email.with+symbol@example.com")
+          (email-address? "#!$%&'*+-/=?^_{}|~@example.com")
           code:blank
           (code:comment @#,elem{See also dns-domain? which applies to everything after the @"@" sign})
           (email-address? "email@123.123.123.123")
-          (email-address? "λ@racket-lang.org")]
+          (email-address? "λ@example.com")]
 
 }
 
@@ -343,12 +343,12 @@ Returns @racket[_addr] if it is a valid email address (according to the same rul
 address is invalid.
 
 @interaction[#:eval mod-constructs
-             (validate-email-address "marian@rclib.org")
+             (validate-email-address "marian@rclib.example.com")
              (validate-email-address "@")
-             (validate-email-address "me@myself@domain.com")
-             (validate-email-address ".marian@rclib.org")
-             (validate-email-address "λ@racket-lang.org")
-             (validate-email-address "lambda@racket.1.com")]
+             (validate-email-address "me@myself@example.com")
+             (validate-email-address ".marian@rclib.example.com")
+             (validate-email-address "λ@example.com")
+             (validate-email-address "lambda@1.example.com")]
 
 }
 

--- a/splitflap-doc/constructs.scrbl
+++ b/splitflap-doc/constructs.scrbl
@@ -9,6 +9,7 @@
                      racket/contract
                      racket/file
                      racket/promise
+                     racket/string
                      splitflap
                      txexpr))
 

--- a/splitflap-doc/constructs.scrbl
+++ b/splitflap-doc/constructs.scrbl
@@ -230,6 +230,8 @@ Returns an @racket[enclosure] for @racket[_file], with a MIME type matching the 
 it can be determined), the URL set to @racket[_file] appended onto @racket[_base-url], and the
 length set to the file’s actual length in bytes.
 
+This procedure accesses the filesystem; if @racket[_file] does not exist, an exception is raised.
+
 @examples[#:eval mod-constructs
           (code:comment @#,elem{Make a temporary file})
           (define audio-file (make-temporary-file "audio-~a.m4a"))

--- a/splitflap-doc/constructs.scrbl
+++ b/splitflap-doc/constructs.scrbl
@@ -380,8 +380,8 @@ Returns @racket[#t] if @racket[_v] is a two-character lowercase symbol matching 
 
 }
 
-@defproc[(language-codes) (listof iso-639-language-code?)]{
+@defthing[language-codes (listof iso-639-language-code?)]{
 
-Returns a list of symbols that qualify as @racket[iso-639-language-code?].
+A list of symbols that qualify as @racket[iso-639-language-code?].
 
 }

--- a/splitflap-doc/mod-splitflap.scrbl
+++ b/splitflap-doc/mod-splitflap.scrbl
@@ -146,11 +146,11 @@ de facto standard for this application.
                   [media enclosure?]
                   [#:duration duration (or/c exact-nonnegative-integer? #f) #f]
                   [#:image-url image-url (or/c valid-url-string? #f) #f]
-                  [#:explicit? explicit (or/c boolean? '_) '_]
+                  [#:explicit? explicit any/c null]
                   [#:episode-num ep-num (or/c exact-nonnegative-integer? #f) #f]
                   [#:season-num s-num (or/c exact-nonnegative-integer? #f) #f]
                   [#:type type (or/c 'trailer 'full 'bonus #f) #f]
-                  [#:block? block boolean? #f])
+                  [#:block? block any/c #f])
          episode?]{
 
 Returns an @racketresultfont{#<episode>} struct, which is required for @racket[podcast]s in the same
@@ -180,6 +180,11 @@ artwork requirements} for other requirements.}
 @item{The @racket[#:duration] gives the episode’s duration in seconds, and is @spec{optional but
 recommended}.}
 
+@item{If @racket[_explicit] is an optional override of the mandatory feed-level parental advisory
+flag in @racket[podcast]. If it is @racket[_null] (the default), the episode will not contain any
+parental advisory information. @spec{If it is @racket[#f], Apple Podcasts will mark the episode as
+“Clean”. If it is any other value, Apple Podcasts will mark the episode as “Explicit”.}
+
 @item{The @racket[#:episode-num] is optional, but @spec{Apple will require it if the
 @racket[podcast] has a type of @racket['episodic].}}
 
@@ -202,10 +207,10 @@ its content would otherwise cause the entire podcast to be removed from Apple Po
                   [category (or/c string? (list/c string? string?))]
                   [image-url valid-url-string?]
                   [owner person?]
-                  [explicit boolean?]
+                  [#:explicit? explicit any/c]
                   [#:type type (or/c 'serial 'episodic #f) #f]
-                  [#:block? block boolean? #f]
-                  [#:complete? complete boolean? #f]
+                  [#:block? block any/c #f]
+                  [#:complete? complete any/c #f]
                   [#:new-feed-url new-url (or/c valid-url-string? #f) #f])
          podcast?]{
 

--- a/splitflap-doc/mod-splitflap.scrbl
+++ b/splitflap-doc/mod-splitflap.scrbl
@@ -183,7 +183,7 @@ recommended}.}
 @item{If @racket[_explicit] is an optional override of the mandatory feed-level parental advisory
 flag in @racket[podcast]. If it is @racket[_null] (the default), the episode will not contain any
 parental advisory information. @spec{If it is @racket[#f], Apple Podcasts will mark the episode as
-“Clean”. If it is any other value, Apple Podcasts will mark the episode as “Explicit”.}
+“Clean”. If it is any other value, Apple Podcasts will mark the episode as “Explicit”.}}
 
 @item{The @racket[#:episode-num] is optional, but @spec{Apple will require it if the
 @racket[podcast] has a type of @racket['episodic].}}

--- a/splitflap-doc/mod-splitflap.scrbl
+++ b/splitflap-doc/mod-splitflap.scrbl
@@ -101,10 +101,10 @@ system-language)] is used.
 
 @examples[#:eval mod-feed
           (define item
-            (feed-item (mint-tag-uri "rclib.org" "2012-06" "blog:example-post")
-                       "http://rclib.org/example-post.html"
+            (feed-item (mint-tag-uri "rclib.example.com" "2012-06" "blog:example-post")
+                       "http://rclib.example.com"
                        "Example"
-                       (person "Marion Paroo" "marion@rclib.org")
+                       (person "Marion Paroo" "marion@rclib.example.com")
                        (infer-moment "2013-04-13 08:45")
                        (infer-moment "2013-04-14")
                        '(article (p "Etc…"))))
@@ -132,7 +132,7 @@ A parameter that, when not set to @racket[#f], is used by @racket[express-xml] a
 
 @section{Podcasts}
 
-Splitflap provides some special data types for podcast feeds: @racket[epsisode] and
+Splitflap provides some special data types for podcast feeds: @racket[episode] and
 @racket[podcast]. These are patterned after @AppleRequirements[] since those serve as a kind of
 de facto standard for this application.
 
@@ -236,10 +236,10 @@ in Apple’s podcast listings.}
 
 @itemlist[
 
-@item{Use @racket['episodic] when episodes are not
-intended to be consumed in any particular order: @spec{in this case, Apple Podcasts will present
-newest episodes first. (If organized into seasons, the newest season will be presented first;
-otherwise, episodes will be grouped by year published, newest first.)}}
+@item{Use @racket['episodic] when episodes are not intended to be consumed in any particular order:
+@spec{in this case, Apple Podcasts will present newest episodes first. (If organized into seasons,
+the newest season will be presented first; otherwise, episodes will be grouped by year published,
+newest first.)}}
 
 @item{Use @racket['serial] when
 episodes are intended to be consumed in sequential order: @spec{in this case, Apple Podcasts will

--- a/splitflap-doc/mod-splitflap.scrbl
+++ b/splitflap-doc/mod-splitflap.scrbl
@@ -51,9 +51,8 @@ The @racket[_author] argument must be a @racket[person] struct.
 
 The value of @racket[_updated] must be identical to or after @racket[_published], taking time zone
 information into account, or an exception is raised. The values for these arguments can be most
-conveniently supplied by @racket[infer-moment], but you can use functions in the
-@racketmodname[gregor] library or any other library which return @racket[moment]s, such as
-@racket[parse-moment].
+conveniently supplied by @racket[infer-moment], but any moment-producing method will work, such as
+constructing @racket[moment]s directly, parsing strings with @racket[parse-moment], etc.
 
 You can optionally use the @racket[_media] argument to supply an @tech{enclosure}, but if you are
 generating a feed for a podcast you should consider using @racket[episode] and @racket[podcast]
@@ -160,9 +159,8 @@ way that @racket[feed-item]s are required for @racket[feed]s. You can inspect it
 
 The value of @racket[_updated] must be identical to or after @racket[_published], taking time zone
 information into account, or an exception is raised. The values for these arguments can be most
-conveniently supplied by @racket[infer-moment], but you can use functions in the
-@racketmodname[gregor] library or any other library which return @racket[moment]s, such as
-@racket[parse-moment].
+conveniently supplied by @racket[infer-moment], but any moment-producing method will work, such as
+constructing @racket[moment]s directly, parsing strings with @racket[parse-moment], etc.
 
 Below are further notes about particular elements supplied to @racket[episode]. The @spec{colored
 passages} indicate things which are required by Apple for inclusion in the Apple Podcasts directory

--- a/splitflap-doc/tutorial.scrbl
+++ b/splitflap-doc/tutorial.scrbl
@@ -20,7 +20,7 @@ date, and a specific identifier:
 @(examples
   #:eval tutorial
   #:label #false
-  (define my-id (mint-tag-uri "my-domain.com" "2012" "blog")))
+  (define my-id (mint-tag-uri "example.com" "2012" "blog")))
 
 The idiomatic route is to create a tag URI for the entire feed, and then append to that URI to
 create tag URIs for the individual items in that feed.
@@ -40,12 +40,12 @@ For this tutorial, we’ll manually make a list with just one @racket[feed-item]
   (define my-items
     (list
      (feed-item
-      (append-specific my-id "first-post")       (code:comment @#,elem{item-specific ID})
-      "https://my-domain.com/first-post.html"    (code:comment @#,elem{URL})
-      "Chaucer, Rabelais and Balzac"             (code:comment @#,elem{title})
-      (person "Marian Paroo" "marian@rclib.org") (code:comment @#,elem{author})
-      (infer-moment "1912-06-21")                (code:comment @#,elem{publish date})
-      (infer-moment "1912-06-21")                (code:comment @#,elem{updated date})
+      (append-specific my-id "first-post")         (code:comment @#,elem{item-specific ID})
+      "https://example.com/first-post.html"        (code:comment @#,elem{URL})
+      "Chaucer, Rabelais and Balzac"               (code:comment @#,elem{title})
+      (person "Marian Paroo" "marian@example.com") (code:comment @#,elem{author})
+      (infer-moment "1912-06-21")                  (code:comment @#,elem{publish date})
+      (infer-moment "1912-06-21")                  (code:comment @#,elem{updated date})
       '(article (p "My first post; content TK"))))))
 
 
@@ -59,7 +59,7 @@ The @racket[feed] struct combines all the elements we’ve created so far:
   (define my-feed
     (feed
      my-id                     (code:comment @#,elem{tag URI})
-     "http://rclib.org/blog"   (code:comment @#,elem{site URL})
+     "http://example.com/blog" (code:comment @#,elem{site URL})
      "River City Library Blog" (code:comment @#,elem{Title})
      my-items)))
 
@@ -71,7 +71,7 @@ Final step: pass your feed to @racket[express-xml], specifying either the @racke
 @(examples
   #:eval tutorial
   #:label #false
-  (display (express-xml my-feed 'atom "https://rclib.org/feed.atom")))
+  (display (express-xml my-feed 'atom "https://example.com/feed.atom")))
 
 There you go! Save that string in a file and you’ve got yourself a valid Atom 1.0 feed.
 
@@ -80,7 +80,7 @@ Let’s do one in RSS format, for kicks. Note the different URL for this version
 @(examples
   #:eval tutorial
   #:label #false
-  (display (express-xml my-feed 'rss "https://rclib.org/feed.rss")))
+  (display (express-xml my-feed 'rss "https://example.com/feed.rss")))
 
 If you want the result as an X-expression, you can do that too, using the @racket[#:as] keyword
 argument:
@@ -88,7 +88,7 @@ argument:
 @(examples
   #:eval tutorial
   #:label #false
-  (express-xml my-feed 'rss "https://rclib.org/feed.rss" #:as 'xexpr))
+  (express-xml my-feed 'rss "https://example.com/feed.rss" #:as 'xexpr))
 
 @section{Wrap up}
 

--- a/splitflap-lib/constructs.rkt
+++ b/splitflap-lib/constructs.rkt
@@ -446,15 +446,15 @@
 
 ;; ~~ ISO 639 Language codes ~~~~~~~~~~~~~~~~~~~~~
 
-(define (language-codes)
+(define language-codes
   '(ab aa af ak sq am ar an hy as av ae ay az bm ba eu be bn bh bi bs br bg my ca km ch ce ny zh cu cv kw co cr hr cs da dv nl dz en eo et ee fo fj fi fr ff gd gl lg ka de ki el kl gn gu ht ha he hz hi ho hu is io ig id ia ie iu ik ga it ja jv kn kr ks kk rw kv kg ko kj ku ky lo la lv lb li ln lt lu mk mg ms ml mt gv mi mr mh ro mn na nv nd ng ne se no nb nn ii oc oj or om os pi pa ps fa pl pt qu rm rn ru sm sg sa sc sr sn sd si sk sl so st nr es su sw ss sv tl ty tg ta tt te th bo ti to ts tn tr tk tw ug uk ur uz ve vi vo wa cy fy wo xh yi yo za zu))
 
 (define-explained-contract (iso-639-language-code? v)
   "ISO 639 language code symbol"
-  (and (symbol? v) (memq v (language-codes)) #t))
+  (and (symbol? v) (memq v language-codes) #t))
 
 (define/contract system-language (promise/c iso-639-language-code?)
-  (delay
+  (delay/sync
     (match
         (case (system-type 'os)
           [(unix macosx) (bytes->string/utf-8 (system-language+country))]

--- a/splitflap-lib/constructs.rkt
+++ b/splitflap-lib/constructs.rkt
@@ -103,10 +103,10 @@
                    "." longest-valid-label ; 252
                    ".aa"))               ; 255 bytes
   
-  (check-true (dns-domain? "joeldueck.com"))
-  (check-true (dns-domain? "joeldueck.com"))
-  (check-true (dns-domain? "joel-dueck.com"))
-  (check-true (dns-domain? "ALLCAPS.COM"))
+  (check-true (dns-domain? "example.com"))
+  (check-true (dns-domain? "example.com"))
+  (check-true (dns-domain? "ex-ample.com"))
+  (check-true (dns-domain? "EXAMPLE.COM"))
   (check-true (dns-domain? "a12-345.b6-78"))
   (check-true (dns-domain? "a"))
   (check-true (dns-domain? "a.b.c.d.e.f.g.h"))
@@ -114,11 +114,11 @@
   (check-true (dns-domain? (string-append longest-valid-label ".com")))
   (check-true (dns-domain? longest-valid-domain))
   
-  (check-false (dns-domain? " joeldueck.com")) ; leading space
-  (check-false (dns-domain? "joeldueck.com ")) ; trailing space
-  (check-false (dns-domain? "joel dueck.com")) ; internal space
-  (check-false (dns-domain? "joeldueck-.com")) ; label ending in hyphen
-  (check-false (dns-domain? "joeldueck.com-")) ; another
+  (check-false (dns-domain? " example.com")) ; leading space
+  (check-false (dns-domain? "example.com ")) ; trailing space
+  (check-false (dns-domain? "ex ample.com")) ; internal space
+  (check-false (dns-domain? "example-.com")) ; label ending in hyphen
+  (check-false (dns-domain? "example.com-")) ; another
   (check-false (dns-domain? "12345.b"))        ; label starting with number
   (check-false (dns-domain? "a12345.678"))     ; another
   (check-false (dns-domain? (string-append longest-valid-label "a")))
@@ -201,16 +201,16 @@
            #t))))
 
 (module+ test
-  (check-true (valid-url-string? "https://joeldueck.com"))
-  (check-true (valid-url-string? "ftp://joeldueck.com"))          ; FTP scheme
-  (check-true (valid-url-string? "gonzo://joeldueck.com"))        ; scheme need not be registered
-  (check-true (valid-url-string? "https://user:p@joeldueck.com")) ; includes user/password
-  (check-true (valid-url-string? "https://joeldueck.com:8080"))   ; includes port
+  (check-true (valid-url-string? "https://example.com"))
+  (check-true (valid-url-string? "ftp://example.com"))          ; FTP scheme
+  (check-true (valid-url-string? "gonzo://example.com"))        ; scheme need not be registered
+  (check-true (valid-url-string? "https://user:p@example.com")) ; includes user/password
+  (check-true (valid-url-string? "https://example.com:8080"))   ; includes port
   (check-true (valid-url-string? "file://C:\\home\\user?q=me"))   ; OK whatever
 
   ;; Things that are valid URIs but not valid URLs
   (check-false (valid-url-string? "news:comp.servers.unix")) ; no host given, only path
-  (check-false (valid-url-string? "http://joel dueck.com"))  ; domain not RFC 1035 compliant
+  (check-false (valid-url-string? "http://ex ample.com"))  ; domain not RFC 1035 compliant
 
   ;; Things that are actually valid URLs but I say nuh-uh, not for using in feeds
   (check-false (valid-url-string? "ldap://[2001:db8::7]/c=GB?objectClass?one"))
@@ -334,14 +334,14 @@
      (txexpr entity '() (list (format "~a (~a)" email name)))]))
   
 (module+ test
-  (define joel (make-person "Joel" "joel@msn.com"))
+  (define joel (make-person "Joel" "joel@example.com"))
   (check-true (person? joel))
-  (check-equal? (person->xexpr joel 'author 'rss) '(author "joel@msn.com (Joel)"))
-  (check-equal? (person->xexpr joel 'author 'atom) '(author (name "Joel") (email "joel@msn.com")))
+  (check-equal? (person->xexpr joel 'author 'rss) '(author "joel@example.com (Joel)"))
+  (check-equal? (person->xexpr joel 'author 'atom) '(author (name "Joel") (email "joel@example.com")))
 
   ;; Prefixing child elements
   (check-equal? (person->xexpr joel 'itunes:owner 'itunes)
-                '(itunes:owner (itunes:name "Joel") (itunes:email "joel@msn.com"))))
+                '(itunes:owner (itunes:name "Joel") (itunes:email "joel@example.com"))))
 
 ;; ~~ MIME types ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -400,38 +400,38 @@
 (module+ test
   (require racket/file)
   (check-exn exn:fail:contract? (λ () (enclosure "invalid-url" "audio/x-m4a" 1234)))
-  (check-exn exn:fail:contract? (λ () (enclosure "http://d.com/f.e" -900 1234)))
-  (check-exn exn:fail:contract? (λ () (enclosure "http://d.com/f.e" "audio/x-m4a" -1)))
+  (check-exn exn:fail:contract? (λ () (enclosure "http://example.com/f.e" -900 1234)))
+  (check-exn exn:fail:contract? (λ () (enclosure "http://example.com/f.e" "audio/x-m4a" -1)))
 
   (define test-enc
-    (enclosure "gopher://umn.edu/greeting.m4a" "audio/x-m4a" 1234))
+    (enclosure "gopher://example.com/greeting.m4a" "audio/x-m4a" 1234))
 
   (check-txexprs-equal?
    (express-xml test-enc 'atom #:as 'xexpr)
    '(link [[rel "enclosure"]
-           [href "gopher://umn.edu/greeting.m4a"]
+           [href "gopher://example.com/greeting.m4a"]
            [length "1234"]
            [type "audio/x-m4a"]]))
   
   (check-txexprs-equal?
    (express-xml test-enc 'rss #:as 'xexpr)
-   '(enclosure [[url "gopher://umn.edu/greeting.m4a"]
+   '(enclosure [[url "gopher://example.com/greeting.m4a"]
                 [length "1234"]
                 [type "audio/x-m4a"]]))
 
   ;; Enclosure with unknown type
   (define test-enc2
-    (enclosure "gopher://umn.edu/greeting.m4a" #f 1234))
+    (enclosure "gopher://example.com/greeting.m4a" #f 1234))
   
   (check-txexprs-equal?
    (express-xml test-enc2 'atom #:as 'xexpr)
    '(link [[rel "enclosure"]
-           [href "gopher://umn.edu/greeting.m4a"]
+           [href "gopher://example.com/greeting.m4a"]
            [length "1234"]]))
   
   (check-txexprs-equal?
    (express-xml test-enc2 'rss  #:as 'xexpr)
-   '(enclosure [[url "gopher://umn.edu/greeting.m4a"]
+   '(enclosure [[url "gopher://example.com/greeting.m4a"]
                 [length "1234"]])))
 
 ;; Convenient way to make an enclosure if you have an existing file

--- a/splitflap-lib/constructs.rkt
+++ b/splitflap-lib/constructs.rkt
@@ -35,7 +35,6 @@
          (rename-out [make-person person])
          person->xexpr
          ; Moments
-         feed-timezone
          infer-moment
          moment->string
          ; Enclosures
@@ -290,14 +289,6 @@
 
 ;; ~~ Dates ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-(define feed-timezone
-  (make-parameter
-   #f
-   (λ (v)
-     (unless (or (tz/c v) (not v))
-       (raise-argument-error 'feed-timezone "an IANA time zone identifier, UTC offset in seconds, or #false" v))
-     v)))
-
 (define (n: v) (cond [(not v) 0] [(string? v) (string->number v)] [else v]))
 
 (define/contract (infer-moment str)
@@ -306,8 +297,7 @@
     #px"^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])(?:\\s+([01]?[0-9]|2[0-3]):([0-5][0-9])(?::([0-5][0-9]|60))?)?")
   (match str
     [(pregexp date/time-regex (list _ y m d hr min sec))
-     (parameterize ([current-timezone (or (feed-timezone) (current-timezone))])
-       (moment (n: y) (n: m) (n: d) (n: hr) (n: min) (n: sec) 0))]
+       (moment (n: y) (n: m) (n: d) (n: hr) (n: min) (n: sec) 0)]
     [_ (raise-argument-error 'Date "string in the format ‘YYYY-MM-DD [hh:mm[:ss]]’" str)]))
 
 (define/contract (moment->string m type)

--- a/splitflap-lib/main.rkt
+++ b/splitflap-lib/main.rkt
@@ -182,7 +182,7 @@
          (guid [[isPermaLink "false"]] ,(tag-uri->string id))
          (description ,(if to-xml? (as-cdata content) (cdata-string (as-cdata content))))
          ,@(if/sp duration `(itunes:duration ,(number->string duration)))
-         ,@(if/sp (boolean? explicit?) `(itunes:explicit ,(if explicit? "true" "false")))
+         ,@(if/sp (not (null? explicit?)) `(itunes:explicit ,(if explicit? "true" "false")))
          ,@(if/sp image-url `(itunes:image [[href ,image-url]]))
          ,@(if/sp episode-n `(itunes:episode ,(number->string episode-n)))
          ,@(if/sp season-n `(itunes:season ,(number->string season-n)))
@@ -196,7 +196,7 @@
 (define/contract (make-episode id url title author published updated content media
                                #:duration [duration #f]
                                #:image-url [image-url #f]
-                               #:explicit? [explicit? '_]
+                               #:explicit? [explicit? null]
                                #:episode-num [episode-n #f]
                                #:season-num [season-n #f]
                                #:type [type #f]
@@ -204,11 +204,11 @@
   (->* (tag-uri? valid-url-string? string? person? moment? moment? xexpr? enclosure?)
        (#:duration (or/c exact-nonnegative-integer? #f)
         #:image-url (or/c valid-url-string? #f)
-        #:explicit? (or/c boolean? '_)
+        #:explicit? any/c
         #:episode-num (or/c exact-nonnegative-integer? #f)
         #:season-num (or/c exact-nonnegative-integer? #f)
         #:type (or/c 'trailer 'full 'bonus #f)
-        #:block? boolean?)
+        #:block? any/c)
        episode?)
   (unless (moment>=? updated published)
     (raise-arguments-error 'feed-item "updated timestamp cannot come before published timestamp"
@@ -265,7 +265,8 @@
        [(xml) (xml-document feed-xpr)]
        [(xml-string) (indented-xml-string feed-xpr #:document? #t)]))])
 
-(define/contract (make-podcast id site-url name entries category image-url owner explicit?
+(define/contract (make-podcast id site-url name entries category image-url owner
+                               #:explicit? explicit?
                                #:type [type #f]
                                #:block? [block? #f]
                                #:complete? [complete? #f]
@@ -277,10 +278,10 @@
         (or/c string? (list/c string? string?))
         valid-url-string?
         person?
-        boolean?)
+        #:explicit? any/c)
        (#:type (or/c 'serial 'episodic #f)
-        #:block? boolean?
-        #:complete? boolean?
+        #:block? any/c
+        #:complete? any/c
         #:new-feed-url (or/c valid-url-string? #f))
        podcast?)
   (podcast_ id site-url name entries category image-url owner explicit? type block? complete? new-feed-url))

--- a/splitflap-lib/tests.rkt
+++ b/splitflap-lib/tests.rkt
@@ -3,12 +3,13 @@
 ;; Unit tests
 
 (require "main.rkt"
+         gregor
          racket/format
          rackunit)
 
 (define site-id (mint-tag-uri "example.com" "2007" "blog"))
 (define e1
-  (parameterize ([feed-timezone 0])
+  (parameterize ([current-timezone 0])
     (feed-item (append-specific site-id "one")
                 "https://example.com/blog/one.html"
                 "Kate's First Post"

--- a/splitflap-lib/tests.rkt
+++ b/splitflap-lib/tests.rkt
@@ -109,3 +109,75 @@
                [feed-language 'en])
   (check-equal? (express-xml f1 'atom "https://example.com/feed.atom") expect-feed-atom)
   (check-equal? (express-xml f1 'rss "https://example.com/feed.rss") expect-feed-rss))
+
+(define test-ep1
+  (parameterize ([current-timezone 0])
+  (episode (append-specific site-id "ep1")
+           "http://example.com/ep1"
+           "Kate Speaks"
+           (person "Kate Poster" "kate@example.com")
+           (infer-moment "2021-10-31")
+           (infer-moment "2021-10-31")
+           `(article (p "Welcome to the show"))
+          (enclosure "http://example.com/ep1.m4a" "audio/x-m4a" 1234)
+           )))
+
+(define expect-ep1 @~a{
+<item>
+  <title>Kate Speaks</title>
+  <link>http://example.com/ep1</link>
+  <pubDate>Sun, 31 Oct 2021 00:00:00 +0000</pubDate>
+  <enclosure url="http://example.com/ep1.m4a" length="1234" type="audio/x-m4a" />
+  <author>kate@"@"example.com (Kate Poster)</author>
+  <guid isPermaLink="false">tag:example.com,2007:blog.ep1</guid>
+  <description>
+    <![CDATA[<article><p>Welcome to the show</p></article>]]>
+  </description>
+</item>
+})
+
+(check-equal? expect-ep1 (express-xml test-ep1 'rss))
+(check-equal? expect-ep1 (express-xml test-ep1 'atom)) ; ignores dialect
+                                        ;
+(define test-ep2
+  (parameterize ([current-timezone 0])
+  (episode (append-specific site-id "ep2")
+           "http://example.com/ep2"
+           "Kate Speaks"
+           (person "Kate Poster" "kate@example.com")
+           (infer-moment "2021-10-31")
+           (infer-moment "2021-10-31")
+           `(article (p "Welcome to another show"))
+          (enclosure "http://example.com/ep2.m4a" "audio/x-m4a" 1234)
+          #:duration 300
+          #:image-url "http://example.com/ep1-cover.png"
+          #:explicit? (even? 7)
+          #:episode-num 2
+          #:season-num 1
+          #:type 'full
+          #:block? (< 3 17 99)
+           )))
+
+(define expect-ep2 @~a{
+<item>
+  <title>Kate Speaks</title>
+  <link>http://example.com/ep2</link>
+  <pubDate>Sun, 31 Oct 2021 00:00:00 +0000</pubDate>
+  <enclosure url="http://example.com/ep2.m4a" length="1234" type="audio/x-m4a" />
+  <itunes:episodeType>full</itunes:episodeType>
+  <author>kate@"@"example.com (Kate Poster)</author>
+  <guid isPermaLink="false">tag:example.com,2007:blog.ep2</guid>
+  <description>
+    <![CDATA[<article><p>Welcome to another show</p></article>]]>
+  </description>
+  <itunes:duration>300</itunes:duration>
+  <itunes:explicit>false</itunes:explicit>
+  <itunes:image href="http://example.com/ep1-cover.png" />
+  <itunes:episode>2</itunes:episode>
+  <itunes:season>1</itunes:season>
+  <itunes:block>Yes</itunes:block>
+</item>
+})
+
+(check-equal? expect-ep2 (express-xml test-ep2 'rss))
+(check-equal? expect-ep2 (express-xml test-ep2 'atom)) ; ignores dialect


### PR DESCRIPTION
Low hanging fruit [courtesy of][1] @zyrolasting and @liberalartist.

- [X] Prefer `example.com` for domain/email examples
- [x] Allow `any/c` for boolean arguments
- [x] `language-codes` should be a value vs procedure
- ~Loosen up contract boundaries~ Separate PR
- [x] Use `delay/sync` for `system-language`

See #2 for work on XML character escaping. I’ll be opening separate PRs for improving handling of time zones and MIME types, and for potentially removing the `txexpr` dependency.

[1]: https://groups.google.com/g/racket-users/c/jpCOkZDtZ_k