### PR TITLE
Remove dependency on `txexpr` package

### DIFF
--- a/splitflap-lib/info.rkt
+++ b/splitflap-lib/info.rkt
@@ -5,7 +5,6 @@
 
 (define deps '("gregor-lib"
                "rackunit-lib"
-               "txexpr"
                "base"))
 (define build-deps '("rackunit-lib"))
 (define compile-omit-paths '("private/build.rkt"))

--- a/splitflap-lib/private/feed.rkt
+++ b/splitflap-lib/private/feed.rkt
@@ -7,7 +7,6 @@
          "validation.rkt"
          gregor
          (only-in net/url url?)
-         txexpr
          racket/contract
          racket/generic
          racket/list

--- a/splitflap-lib/private/validation.rkt
+++ b/splitflap-lib/private/validation.rkt
@@ -1,7 +1,6 @@
 #lang racket/base
 
-(require (for-syntax racket/base)
-         "dust.rkt"
+(require "dust.rkt"
          "xml-generic.rkt"
          gregor
          net/url-string
@@ -36,20 +35,6 @@
          iso-639-language-code?
          language-codes
          system-language)
-
-;; (private) convenience macro
-(define-syntax (define-explained-contract stx)
-  (syntax-case stx ()
-    [(_ (NAME VAL) EXPECTED TEST-EXPR)
-     #'(define NAME
-         (flat-contract-with-explanation
-          (λ (VAL)
-            (cond
-              [TEST-EXPR]
-              [else
-               (λ (blame)
-                 (raise-blame-error blame VAL '(expected: EXPECTED given: "~e") VAL))]))
-          #:name 'NAME))]))
 
 ;; ~~ DNS Domain validation (RFC 1035) ~~~~~~~~~~~
 ;;

--- a/splitflap-lib/tests.rkt
+++ b/splitflap-lib/tests.rkt
@@ -49,7 +49,7 @@
     <link rel="alternate" href="https://example.com/blog/one.html" />
     <updated>2007-03-17T00:00:00Z</updated>
     <published>2007-03-17T00:00:00Z</published>
-    <link rel="enclosure" type="audio/x-m4a" length="1234" href="gopher://umn.edu/greeting.m4a" />
+    <link rel="enclosure" href="gopher://umn.edu/greeting.m4a" length="1234" type="audio/x-m4a" />
     <author>
       <name>Kate Poster</name>
       <email>kate@example.com</email>
@@ -109,7 +109,7 @@ END
     <link rel="alternate" href="https://example.com/blog/one.html" />
     <updated>2007-03-17T00:00:00Z</updated>
     <published>2007-03-17T00:00:00Z</published>
-    <link rel="enclosure" type="audio/x-m4a" length="1234" href="gopher://umn.edu/greeting.m4a" />
+    <link rel="enclosure" href="gopher://umn.edu/greeting.m4a" length="1234" type="audio/x-m4a" />
     <author>
       <name>Kate Poster</name>
       <email>kate@example.com</email>


### PR DESCRIPTION
I only use three functions from this package, so a few lightweight, hand-rolled substitutes allows me to shed a dependency.

Still have to do some testing to ensure that user-facing error messages and validation haven’t degraded as a result.